### PR TITLE
fix(ci): Increase timeout for golangci lint action

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           version: v1.54
           working-directory: ./backend
+          args: --timeout=5m --verbose
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
golangci lint action sometimes took more than 1 minute would make ci failed (default timeout is 60 seconds)
We may increase the timeout for the workaround of this problem as it is not addressed currently.

Ref: https://github.com/golangci/golangci-lint-action/issues/297